### PR TITLE
Remove deprecated keyword

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -8,12 +8,12 @@
 
     {{- /* css */}}
     {{ $sass := resources.Get "css/base/base.scss" | resources.ExecuteAsTemplate "style.scss" .  }}
-    {{ $sass_bulma := $sass | resources.ToCSS | minify | resources.Fingerprint }}
+    {{ $sass_bulma := $sass | css.Sass | minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $sass_bulma.Permalink }}" integrity="{{ $sass_bulma.Data.Integrity }}">
 
 
     {{ $sass := resources.Get "css/extra/extra.scss" | resources.ExecuteAsTemplate "style.scss" .   }}
-    {{ $sass_extra := $sass | resources.ToCSS | minify | resources.Fingerprint }}
+    {{ $sass_extra := $sass | css.Sass | minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $sass_extra.Permalink }}" integrity="{{ $sass_extra.Data.Integrity }}">
 
 


### PR DESCRIPTION
This will replace the deprecated keyword that was reported in [issue #2](https://github.com/alloydwhitlock/huey/issues/2).

Before merging, understand this will likely break backwards compatibility for Hugo versions older than [v0.114.0](https://gohugo.io/functions/css/sass/#installation-overview).  The change is necessary as in 2023, the Sass team [deprecated](https://gohugo.io/functions/css/sass/#fn:1) Embedded Dart Sass in favor of Dart Sass.